### PR TITLE
Subgraph

### DIFF
--- a/brer.py
+++ b/brer.py
@@ -41,49 +41,70 @@ lengthened_input = gmx.modify_input(
 
 # Create subgraph objects that encapsulate multiple operations
 # and can be used in conditional and loop operations.
-# For subgraphs, inputs can be accessed as variables (not standard input/output)
-# and are copied to the next iteration.
-train = gmx.subgraph(variables={'conformation': initial_input})
+# For subgraphs, inputs can be accessed as variables and are copied to the next
+# iteration (not typical for gmxapi operation input/output).
+train = gmx.subgraph(variables={'conformation': initial_input,
+                                'is_converged': False,
+                                'training_potential': None,
+                                }
+                     )
 
+# References to the results of operations know which (sub)graph they live in.
+# The `with` block activates and deactivates the scope of the subgraph in order
+# to constrain the section of this script in which references are valid.
+# Otherwise, a user could mistakenly use a reference that only points to the
+# result of the first iteration of a "while" loop. If the `with` block succeeds,
+# then the outputs of `train` are afterwards fully specified.
 with train:
-    training_potential = myplugin.training_restraint(
-        'training_restraint', params=my_dict_params)
+    train.training_potential = myplugin.training_restraint(
+        params=my_dict_params)
     modified_input = gmx.modify_input(
         input=initial_input, structure=train.conformation)
-    md = gmx.mdrun(input=modified_input, potential=training_potential)
+    md = gmx.mdrun(input=modified_input, potential=train.training_potential)
     # Alternate syntax to facilitate adding multiple potentials:
-    # md.interface.potential.apend(training_potential)
-    train_condition = brer_tools.training_analyzer(
-        training_potential.output.alpha)
+    # md.interface.potential.add(train.training_potential)
+    train.is_converged = brer_tools.training_analyzer(
+        train.training_potential.output.alpha)
     train.conformation = md.output.conformation
+# At the end of the `with` block, `train` is no longer the active graph, and
+# gmx.exceptions.ScopeError will be raised if `modified_input`, or `md` are used
+# in other graph scopes (without first reassigning, of course)
+# More discussion at https://github.com/kassonlab/gmxapi/issues/205
 
 # In the default work graph, add a node that depends on `condition` and
 # wraps subgraph.
 train_loop = gmx.while_loop(
-    gmx.logical_not(train.train_condition.is_converged), train)
+    operation=train,
+    condition=gmx.logical_not(train.is_converged))
 
 # in this particular application, we "roll back" to the initial input
-converge = gmx.subgraph(variables={'conformation': initial_input})
+converge = gmx.subgraph(variables={'conformation': initial_input,
+                                   'is_converged': False,
+                                   'converging_potential': None,
+                                   }
+                        )
 
 with converge:
     modified_input = gmx.modify_input(
         input=initial_input, structure=converge.conformation)
-    converging_potential = myplugin.converge_restraint(
-        params=training_potential.output)
-    converge_condition = brer_tools.converge_analyzer(
-        converging_potential.output.distances)
-    md = gmx.mdrun(input=modified_input, potential=converging_potential)
+    converge.converging_potential = myplugin.converge_restraint(
+        params=train_loop.training_potential.output)
+    converge.is_converged = brer_tools.converge_analyzer(
+        converge.converging_potential.output.distances)
+    md = gmx.mdrun(input=modified_input, potential=converge.converging_potential)
+
 conv_loop = gmx.while_loop(
-    gmx.logical_not(converge.converge_condition.is_converged), converge)
+    operation=converge,
+    condition=gmx.logical_not(converge.is_converged))
 
 production_input = gmx.modify_input(
     input=initial_input, structure=converge.conformation)
 prod_potential = myplugin.production_restraint(
-    params=converging_potential.output)
+    params=converge.converging_potential.output)
 prod_md = gmx.mdrun(input=production_input, potential=prod_potential)
 
 gmx.run()
 
 print('Final alpha value was {}'.format(
-    training_potential.output.alpha.extract()))
+    train_loop.training_potential.output.alpha.extract()))
 # also can extract conformation filenames, etc.

--- a/restrained_ensemble.py
+++ b/restrained_ensemble.py
@@ -27,7 +27,7 @@ initial_tpr = gmx.commandline_operation('gmx', 'grompp',
                                         input={'-f': run_parameters,
                                         '-p': topology_file,
                                         '-c': starting_structure})
-initial_input = gmx.load_tpr([initial_tpr for _ in range(N)])  # An array of simulations
+initial_input = gmx.read_tpr([initial_tpr for _ in range(N)])  # An array of simulations
 
 with open('params1.json', 'r') as fh:
     restraint1_params = json.load(fh)
@@ -40,20 +40,21 @@ with open('params2.json', 'r') as fh:
 # NDArray syntax in Python is based on numpy user interfaces.
 converge = gmx.subgraph(
     variables={'pair_distance1': gmx.NDArray(0., shape=restraint1_params['nbins']),
-               'pair_distance2': gmx.NDArray(0., shape=restraint2_params['nbins'])}
+               'pair_distance2': gmx.NDArray(0., shape=restraint2_params['nbins']),
+               'is_converged': False}
 )
 
 with converge:
     # ensemble_restraint is implemented using gmxapi ensemble allReduce operations
     # that do not need to be expressed in this procedural interface.
-    potential1 = myplugin.ensemble_restraint('ensemble_restraint_1',
+    potential1 = myplugin.ensemble_restraint(label='ensemble_restraint_1',
                                              params=restraint1_params,
                                              input={'pair_distance': converge.pair_distance1})
-    potential2 = myplugin.ensemble_restraint('ensemble_restraint_2',
+    potential2 = myplugin.ensemble_restraint(label='ensemble_restraint_2',
                                              params=restraint2_params,
                                              input={'pair_distance': converge.pair_distance2})
 
-    md = gmx.mdrun(gmx.read_tpr(initial_input))
+    md = gmx.mdrun(initial_input)
     md.interface.potential.add(potential1)
     md.interface.potential.add(potential2)
 
@@ -63,12 +64,12 @@ with converge:
                         'simulation_distances': gmx.gather(potential1.output.pair_distance)})
     js_2 = calculate_js(input={'params': restraint2_params,
                         'simulation_distances': gmx.gather(potential2.output.pair_distance)})
-    condition = gmx.logical_and(js_1.is_converged, js_2.is_converged)
+    converge.is_converged = gmx.logical_and(js_1.is_converged, js_2.is_converged)
 
     converge.pair_distance1 = potential1.output.pair_distance
     converge.pair_distance2 = potential2.output.pair_distance
 
-work = gmx.while_loop(converge.condition, converge)
+work = gmx.while_loop(operation=converge, condition=gmx.logical_not(converge.is_converged))
 
 # Command-line arguments for mdrun can be added to gmx run as below.
 # Settings for a 20 core HPC node. Use 18 threads for domain decomposition for pair potentials

--- a/run_adaptive_msm.py
+++ b/run_adaptive_msm.py
@@ -29,7 +29,8 @@ editconf = gmx.commandline_operation('gmx', 'editconf',
 # and can be used in a control operation.
 subgraph = gmx.subgraph(variables={
                             'conformation': initial_input,
-                            'P': gmx.NDArray(0., shape=(N, N))
+                            'P': gmx.NDArray(0., shape=(N, N)),
+                            'is_converged': False,
                             })
 
 with subgraph:
@@ -50,9 +51,10 @@ with subgraph:
     subgraph.P = adaptive_msm.output.transition_matrix
     # adaptive_msm here is responsible for maintaining the ensemble width
     subgraph.conformation = adaptive_msm.output.conformation
+    subgraph.is_converged = adaptive_msm.output.is_converged
 
 # In the default work graph, add a node that depends on `condition` and
 # wraps subgraph.
-my_loop = gmx.while_loop(gmx.logical_not(subgraph.adaptive_msm.output.is_converged), subgraph)
+my_loop = gmx.while_loop(operation=subgraph, condition=gmx.logical_not(subgraph.is_converged))
 
 gmx.run()


### PR DESCRIPTION
This change addresses some previously proposed syntax that seemed incomplete or unworkable.

The behavioral goal is to create subgraphs whose internal data flow is not referable from outside of the subgraph, but which have named, scoped properties that
* preserve state between iterative executions of the subgraph, and
* explicitly map data from inside to outside of the subgraph

The mapping is analogous to TensorFlow `Variable`s and looping operations are analogous to training a `Graph` in a `Layer`. I hope the implementation can be ultimately TF compatible, but the syntax is decidedly different in (what we hope is) a cleaner and more user-friendly way.

This PR is based on PR https://github.com/kassonlab/gmxapi-scripts/pull/1 and will be easier to review when that is merged.

* Clarify that subgraphs expose named data externally, mapped to stateful Variables internally.
* Update external references to example subgraph data to use only properties declared on the subgraph (when defining `while` operations) or to the final values (automatically) mapped to `while` operation outputs.
* Change positional arguments to keyword arguments.